### PR TITLE
Fixing typescript definition for pouchdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The I made modifications to the default Ionic app:
 // typings/index.d.ts
 declare module 'pouchdb' {
   var PouchDB: any;
-  export default PouchDB;
+  export = PouchDB;
 }
 ```
 
@@ -33,8 +33,11 @@ Then I imported PouchDB:
 
 ```typescript
 // app/app.ts
-import * as PouchDB from 'pouchdb';
+import PouchDB = require('pouchdb');
 console.log("Hey look, I've got PouchDB:", PouchDB);
+
+let db = new PouchDB('database');
+console.log("Hey look, I've got a PouchDB database:", db);
 ```
 
 Then I started the app:

--- a/app/app.ts
+++ b/app/app.ts
@@ -2,9 +2,12 @@ import {Component} from '@angular/core';
 import {Platform, ionicBootstrap} from 'ionic-angular';
 import {StatusBar} from 'ionic-native';
 import {TabsPage} from './pages/tabs/tabs';
-import * as PouchDB from 'pouchdb';
+import PouchDB = require('pouchdb');
+
+let db = new PouchDB('database');
 
 console.log("Hey look, I've got PouchDB:", PouchDB);
+console.log("Hey look, I've got a PouchDB database:", db);
 
 @Component({
   template: '<ion-nav [root]="rootPage"></ion-nav>'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,5 +2,5 @@
 /// <reference path="modules/lodash/index.d.ts" />
 declare module 'pouchdb' {
   var PouchDB: any;
-  export default PouchDB;
+  export = PouchDB;
 }


### PR DESCRIPTION
The original definition works fine until you try to use the PouchDB object. If you try to create a new database using something like:

``` typescript
let db = new PouchDB('db');
```

The Typescript compiler will complain with the following error:

```
Error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
```

I found documentation on the Typescript page for [modules](https://www.typescriptlang.org/docs/handbook/modules.html) (Scroll to the section titled export = and import = require()) that shows the correct way to define the module. After the changes in the PR both the original code work and it can now be used to create new Databases, sync, etc.. and still make the Typescript compiler happy. 
